### PR TITLE
 examples/qmlscene: fix upstream reference to tutorial3

### DIFF
--- a/examples/qmlscene/tutorial3.qml
+++ b/examples/qmlscene/tutorial3.qml
@@ -1,4 +1,4 @@
-// See http://qt-project.org/doc/qt-5.1/qtquick/qml-tutorial1.html
+// See http://qt-project.org/doc/qt-5.1/qtquick/qml-tutorial3.html
 
 import QtQuick 2.0
 


### PR DESCRIPTION
Fix the link to tutorial3 upstream reference.
