### PR TITLE
Updated the README for the new version of OSX.

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,8 @@ Something along these lines should be effective:
     $ export CGO_CPPFLAGS=-I`brew --prefix qt5`/include/QtCore/$QT5VERSION/QtCore
     $ CXX=g++-4.8 go get github.com/niemeyer/qml
 
+For OSX Mavericks you may need to use `brew install qt5 --HEAD` and check that QT5VERSION is something reasonable like
+`5.2.0`, `ls /usr/local/Cellar/qt5/HEAD/include/QtCore/ | grep '^5'` should also work.
 
 Requirements on Windows
 -----------------------


### PR DESCRIPTION
The version of Qt5 in brew no longer installs on OSX 10.9, and it also messes up the QT5VERSION. Added a note for that onto the OSX install section.
