### PR TITLE
Can I get native (X11) window handles?

### DIFF
--- a/cpp/capi.cpp
+++ b/cpp/capi.cpp
@@ -224,6 +224,11 @@ void windowHide(QQuickWindow_ *win)
     reinterpret_cast<QQuickWindow *>(win)->hide();
 }
 
+uintptr_t windowWinId(QQuickWindow_ *win)
+{
+    return reinterpret_cast<QQuickWindow *>(win)->winId();
+}
+
 void windowConnectHidden(QQuickWindow_ *win)
 {
     QQuickWindow *qwin = reinterpret_cast<QQuickWindow *>(win);

--- a/cpp/capi.h
+++ b/cpp/capi.h
@@ -143,6 +143,7 @@ QQuickWindow_ *componentCreateWindow(QQmlComponent_ *component, QQmlContext_ *co
 
 void windowShow(QQuickWindow_ *win);
 void windowHide(QQuickWindow_ *win);
+uintptr_t windowWinId(QQuickWindow_ *win);
 void windowConnectHidden(QQuickWindow_ *win);
 QObject_ *windowRootObject(QQuickWindow_ *win);
 QImage_ *windowGrabWindow(QQuickWindow_ *win);

--- a/qml.go
+++ b/qml.go
@@ -760,6 +760,15 @@ func (win *Window) Hide() {
 	})
 }
 
+// WinId gets the native window handle.
+func (win *Window) WinId() uintptr {
+	var winId uintptr
+	gui(func() {
+		 winId = uintptr(C.windowWinId(win.addr))
+	})
+	return winId
+}
+
 // Root returns the root object being rendered.
 //
 // If the window was defined in QML code, the root object is the window itself.


### PR DESCRIPTION
I was trying to port a little tool I made with Qt 5.2 to go/qml, but in this tool, I need access to the native X11 handle through the `winId()` QWindow method for sending a X11 message for setting "always on top" flag for the window (this is just a brightness control tool, so this is applicable). It seems there's no `qml.Window` method/member that gives me this native handle so I can use it with [`BurntSushi/xgb`](https://github.com/BurntSushi/xgb)? It would be nice to have access for that.
