### PR TITLE
Hack to enable imgprovider to run from any directory.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ examples/snapweb/snapweb
 examples/particle/particle
 gl/gengl/gengl
 *.swp
+imgprovider

--- a/examples/imgprovider/imgprovider.go
+++ b/examples/imgprovider/imgprovider.go
@@ -2,16 +2,35 @@ package main
 
 import (
 	"fmt"
-	"gopkg.in/v0/qml"
 	"image"
 	"image/png"
 	"os"
+
+	"bitbucket.org/kardianos/osext"
+	"gopkg.in/v0/qml"
 )
 
+// fatal puts formatted msg on std error and exits.
+func fatal(format string, v ...interface{}) {
+	fmt.Fprintf(os.Stderr, format, v...)
+	os.Exit(1)
+}
+
 func main() {
+	dir, e := osext.ExecutableFolder()
+	if nil != e {
+		fatal("osext cannot find executable folder: %v\n", e)
+	}
+	// Changing directory ensures the program can be run from any directory.
+	// Otherwise it cannot find the qml file.
+
+	e = os.Chdir(dir)
+	if nil != e {
+		fatal("cannot change wd to '%s': %v\n", dir, e)
+	}
+
 	if err := run(); err != nil {
-		fmt.Fprintf(os.Stderr, "error: %v\n", err)
-		os.Exit(1)
+		fatal("error: %v\n", err)
 	}
 }
 


### PR DESCRIPTION
To test the ability of imgprovider to use the embedded image, I ran it from my home directory, where it complained that it could not load the qml file.  I've rashly put together a reasonable hack to fix that, by having the program change working directory to the directory where the binary executable resides, in the hope that the qml file will be there.  It works, but...

I now realize that this defeats the purpose of the example, which I understand to be using the image embedded in the executable.  Feel free to incorporate this.  But I think I should research how the qml file could instead be embedded in the runtime binary.  Do you know how to do this?
