### PR TITLE
Update customtype.qml

### DIFF
--- a/examples/customtype/customtype.qml
+++ b/examples/customtype/customtype.qml
@@ -1,5 +1,11 @@
 import GoExtensions 1.0
 
 GoType {
-	text: "Happy " + GoSingleton.event + ", Go!"
+	my_go_text: "Happy " + GoSingleton.event + ", Go!"
+	my_go_int: 999
+	my_go_int64: 1111
+	my_go_float64: 33.33
+	my_go_bool: true
+	my_go_string: "Hello GoType"
+	my_go_color: Qt.rgba(0.5, 0.5, 0, 1)
 }


### PR DESCRIPTION
Added more fields to the GoType structure to clarify that the field names start with an Uppercase letter within the .go file and the field names start with a lowercase letter when used within the .qml file.
