### PR TITLE
Fix memory leak in GoImageProvider

### DIFF
--- a/cpp/capi.cpp
+++ b/cpp/capi.cpp
@@ -140,11 +140,14 @@ class GoImageProvider : public QQuickImageProvider {
             height = requestedSize.height();
         }
         QImage *image = reinterpret_cast<QImage *>(hookRequestImage(imageFunc, (char*)ba.constData(), ba.size(), width, height));
-        *size = image->size();
+        QImage tmp = *image;
+        delete image;
+
+        *size = tmp.size();
         if (requestedSize.isValid() && requestedSize != *size) {
-            *image = image->scaled(requestedSize, Qt::KeepAspectRatio);
+            tmp = tmp.scaled(requestedSize, Qt::KeepAspectRatio);
         }
-        return *image;
+        return tmp;
     };
 
     private:


### PR DESCRIPTION
Qt uses "implicit shared memory" for many of its types which is a scheme
similar to copy on write, and is tracked by reference counting in the
constructors/destructor of its classes.

Unfortunately the image provider code creates an *QImage, which since it
wasn't delete'd the destructor is not called, so when QML is done with its
own copies, the shared image data can't be freed.
