### PR TITLE
cpp/capi.cpp: fix ImageProvider leak

### DIFF
--- a/cpp/capi.cpp
+++ b/cpp/capi.cpp
@@ -139,12 +139,15 @@ class GoImageProvider : public QQuickImageProvider {
             width = requestedSize.width();
             height = requestedSize.height();
         }
-        QImage *image = reinterpret_cast<QImage *>(hookRequestImage(imageFunc, (char*)ba.constData(), ba.size(), width, height));
-        *size = image->size();
+        QImage *ptr = reinterpret_cast<QImage *>(hookRequestImage(imageFunc, (char*)ba.constData(), ba.size(), width, height));
+        QImage image = *ptr;
+        delete ptr;
+
+        *size = image.size();
         if (requestedSize.isValid() && requestedSize != *size) {
-            *image = image->scaled(requestedSize, Qt::KeepAspectRatio);
+            image = image.scaled(requestedSize, Qt::KeepAspectRatio);
         }
-        return *image;
+        return image;
     };
 
     private:


### PR DESCRIPTION
GoImageProvider had a memory leak where it got a pointer to a QImage,
and never freed it. Qt already has a refcounting system in place so every
QImage is actually a pointer to pixel data, but it relies on the destructor
for every QImage instance to be called.
