### PR TITLE
Update README to use qml.v1

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ Then, force brew to "link" qt5 (this makes it available under /usr/local):
 
 And finally, fetch and install go-qml:
 
-    $ go get gopkg.in/qml.v0
+    $ go get gopkg.in/qml.v1
 
 
 Requirements on Windows


### PR DESCRIPTION
qml.v0 seems to be deprecated and doesn't work with the latest Go 1.3.1. Updating the README to reflect this.
