### PR TITLE
change "upstart-app-launch" to "ubuntu-app-launch"

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ run the following commands to get a working build environment inside the device:
 
     $ adb shell
     # cd /tmp
-    # wget https://github.com/go-qml/qml/raw/master/cmd/ubuntu-touch/setup.sh
+    # wget https://github.com/go-qml/qml/raw/v1/cmd/ubuntu-touch/setup.sh
     # /bin/bash setup.sh
     # su - phablet
     $
@@ -92,11 +92,11 @@ At the end of setup.sh, the phablet user will have GOPATH=$HOME in the environme
 the qml package will be built, and the particle example will be built and run. For
 stopping it from the command line, run as the phablet user:
 
-    $ upstart-app-stop gopkg.in.qml.particle-example
+    $ ubuntu-app-stop gopkg.in.qml.particle-example
 
 for running it again:
 
-    $ upstart-app-launch gopkg.in.qml.particle-example
+    $ ubuntu-app-launch gopkg.in.qml.particle-example
 
 These commands depend on the following file, installed by setup.sh:
 

--- a/cmd/ubuntu-touch/setup.sh
+++ b/cmd/ubuntu-touch/setup.sh
@@ -15,7 +15,7 @@ echo 'Installing Go and dependencies -------------------------------------------
 
 apt-get update
 apt-get install -y \
-	golang-go g++ git pkg-config \
+	golang-go g++ git pkg-config ubuntu-app-launch\
 	qtbase5-private-dev qtdeclarative5-private-dev libqt5opengl5-dev
 apt-get clean
 
@@ -38,4 +38,4 @@ su -l phablet -c 'cd $HOME/src/gopkg.in/qml.v0/examples/particle; go build'
 
 echo 'Launching particle example ---------------------------------------------------'
 
-su -l phablet -c "upstart-app-launch $APP_ID"
+su -l phablet -c "ubuntu-app-launch $APP_ID"


### PR DESCRIPTION
root@ubuntu-phablet:~# apt-get install upstart-app-launch
Reading package lists... Done
Building dependency tree  
Reading state information... Done
Note, selecting 'ubuntu-app-launch' instead of 'upstart-app-launch'
ubuntu-app-launch is already the newest version.
