### PR TITLE
Fix for error: narrowing conversion from 'QtMsgType' to 'int'

### DIFF
--- a/cpp/capi.cpp
+++ b/cpp/capi.cpp
@@ -847,7 +847,7 @@ QQmlListProperty_ *newListProperty(GoAddr *addr, intptr_t reflectIndex, intptr_t
 void internalLogHandler(QtMsgType severity, const QMessageLogContext &context, const QString &text)
 {
     QByteArray textba = text.toUtf8();
-    LogMessage message = {severity, textba.constData(), textba.size(), context.file, (int)strlen(context.file), context.line};
+    LogMessage message = {static_cast<int>(severity), textba.constData(), textba.size(), context.file, (int)strlen(context.file), context.line};
     hookLogHandler(&message);
 }
 


### PR DESCRIPTION
Fix for error: narrowing conversion of 'severity' from 'QtMsgType' to 'int'

I've followed the instructions to install MinGW and Qt (and the missing pkg-config) on windows/386. Then I've tried to do:

``` go
go build imgprovider.go 
```

to build that example and I encountered the above error. After consulting the question in [here](http://stackoverflow.com/questions/4434140/narrowing-conversions-in-c0x-is-it-just-me-or-does-this-sound-like-a-breakin) the build passed and the gopher+Ubuntu logo finally appeared on the screen.
