### PR TITLE
Add support for Qt 5.4 WebEngine

### DIFF
--- a/examples/webengine/webengine.go
+++ b/examples/webengine/webengine.go
@@ -1,0 +1,27 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"gopkg.in/qml.v1"
+	"gopkg.in/qml.v1/webengine"
+)
+
+func main() {
+	fmt.Println(qml.Run(func() error {
+		webengine.Initialize()
+
+		engine := qml.NewEngine()
+		engine.On("quit", func() { os.Exit(0) })
+
+		component, err := engine.LoadFile("webengine.qml")
+		if err != nil {
+			return err
+		}
+		win := component.CreateWindow(nil)
+		win.Show()
+		win.Wait()
+		return nil
+	}))
+}

--- a/examples/webengine/webengine.qml
+++ b/examples/webengine/webengine.qml
@@ -1,0 +1,14 @@
+import QtQuick 2.1
+import QtWebEngine 1.0
+import QtQuick.Controls 1.0
+
+ApplicationWindow {
+    id: root
+    width: 1024
+    height: 768
+    
+    WebEngineView {
+        anchors.fill: parent
+        url: "http://codingame.com"
+    }
+}

--- a/webengine/webengine.cpp
+++ b/webengine/webengine.cpp
@@ -1,0 +1,6 @@
+#include <QtWebEngine>
+#include "webengine.h"
+
+void webengineInitialize() {
+	QtWebEngine::initialize();
+}

--- a/webengine/webengine.go
+++ b/webengine/webengine.go
@@ -1,0 +1,20 @@
+package webengine
+
+// #cgo CPPFLAGS: -I./
+// #cgo CXXFLAGS: -std=c++0x -pedantic-errors -Wall -fno-strict-aliasing
+// #cgo LDFLAGS: -lstdc++
+// #cgo pkg-config: Qt5WebEngine
+//
+// #include "webengine.h"
+import "C"
+
+import (
+	"gopkg.in/qml.v1"
+)
+
+// Initializes the WebEngine extension.
+func Initialize() {
+	qml.RunMain(func() {
+		C.webengineInitialize()
+	})
+}

--- a/webengine/webengine.h
+++ b/webengine/webengine.h
@@ -1,0 +1,14 @@
+#ifndef WEBENGINE_H
+#define WEBENGINE_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void webengineInitialize();
+
+#ifdef __cplusplus
+} // extern "C"
+#endif
+
+#endif // WEBENGINE_H


### PR DESCRIPTION
I've implemented a simple wrapper around the webengine initialization function call to be able to use QtWebEngine QML modules too in go-qml applications. I've placed it in a separate folder so that only people needing it will have to have the Qt 5.4 dependencies installed. I've also added a simple example loading the CodinGame website which is very heavy on animation (hence why webkit fails utterly with it).
