### PR TITLE
several errors in Windows

### DIFF
--- a/cpp/capi.cpp
+++ b/cpp/capi.cpp
@@ -1,9 +1,9 @@
-#include <QApplication>
-#include <QQuickView>
-#include <QQuickItem>
-#include <QtQml>
-#include <QDebug>
-#include <QQuickImageProvider>
+#include <QtWidgets/QApplication>
+#include <QtQuick/QQuickView>
+#include <QtQuick/QQuickItem>
+#include <QtQml/QtQml>
+#include <QtCore/QDebug>
+#include <QtQuick/QQuickImageProvider>
 
 #include <string.h>
 

--- a/cpp/connector.cpp
+++ b/cpp/connector.cpp
@@ -1,4 +1,4 @@
-#include <QObject>
+#include <QtCore/QObject>
 
 #include "connector.h"
 #include "capi.h"

--- a/cpp/connector.h
+++ b/cpp/connector.h
@@ -1,7 +1,7 @@
 #ifndef CONNECTOR_H
 #define CONNECTOR_H
 
-#include <QObject>
+#include <QtCore/QObject>
 
 #include <stdint.h>
 

--- a/cpp/govalue.cpp
+++ b/cpp/govalue.cpp
@@ -4,8 +4,8 @@
 #include <QtOpenGL/QGLFunctions>
 
 #include <QtQml/QtQml>
-#include <QQmlEngine>
-#include <QDebug>
+#include <QtQml/QQmlEngine>
+#include <QtCore/QDebug>
 
 #include "govalue.h"
 #include "capi.h"

--- a/cpp/govalue.h
+++ b/cpp/govalue.h
@@ -6,8 +6,8 @@
 // away, and without it this package wouldn't exist.
 #include <private/qmetaobject_p.h>
 
-#include <QQuickPaintedItem>
-#include <QPainter>
+#include <QtQuick/QQuickPaintedItem>
+#include <QtGui/QPainter>
 
 #include "capi.h"
 

--- a/cpp/idletimer.cpp
+++ b/cpp/idletimer.cpp
@@ -1,6 +1,6 @@
-#include <QBasicTimer>
-#include <QThread>
-#include <QDebug>
+#include <QtCore/QBasicTimer>
+#include <QtCore/QThread>
+#include <QtCore/QDebug>
 #include <mutex>
 
 #include "capi.h"

--- a/cpp/idletimer.cpp
+++ b/cpp/idletimer.cpp
@@ -12,8 +12,8 @@ class IdleTimer : public QObject
     public:
 
     static IdleTimer *singleton() {
-        static IdleTimer singleton;
-        return &singleton;
+		if (_singleton == nullptr) _singleton = new IdleTimer;
+        return _singleton;
     }
 
     void init(int32_t *guiIdleRun)
@@ -38,12 +38,15 @@ class IdleTimer : public QObject
         }
     }
 
+	static IdleTimer* _singleton;
     private:
 
     int32_t *guiIdleRun;
 
     QBasicTimer timer;    
 };
+
+IdleTimer* IdleTimer::_singleton;
 
 void idleTimerInit(int32_t *guiIdleRun)
 {

--- a/gl/es2/gl.go
+++ b/gl/es2/gl.go
@@ -4,8 +4,9 @@ package GL
 
 // #cgo CXXFLAGS: -std=c++0x -pedantic-errors -Wall -fno-strict-aliasing
 // #cgo LDFLAGS: -lstdc++
-// #cgo !darwin LDFLAGS: -lGL
+// #cgo !darwin,!windows LDFLAGS: -lGL
 // #cgo  darwin LDFLAGS: -framework OpenGL
+// #cgo  windows LDFLAGS: -lopengl32
 // #cgo pkg-config: Qt5Core Qt5OpenGL
 //
 // #include "funcs.h"


### PR DESCRIPTION
Reason of first push:
I  run the example ( "painting-es2"). But I get a error to install "gl/es2" package.
And in Windows, the linker of OpenGL is not "GL". It should be "opengl32".
I test it in Windows 8.1 with Go1.3.3 and Qt5.3.2.
