### PR TITLE
Fixed unsupported variant type: 1024 (QJSValue)

### DIFF
--- a/cpp/capi.cpp
+++ b/cpp/capi.cpp
@@ -855,6 +855,8 @@ QQmlListProperty_ *newListProperty(GoAddr *addr, intptr_t reflectIndex, intptr_t
 
 void internalLogHandler(QtMsgType severity, const QMessageLogContext &context, const QString &text)
 {
+    if (context.file == NULL) return;
+
     QByteArray textba = text.toUtf8();
     LogMessage message = {severity, textba.constData(), textba.size(), context.file, (int)strlen(context.file), context.line};
     hookLogHandler(&message);

--- a/cpp/capi.cpp
+++ b/cpp/capi.cpp
@@ -745,7 +745,8 @@ void packDataValue(QVariant_ *var, DataValue *value)
         break;
     case QMetaType::User:
         {
-            if (qvar->userType() == 1034) {
+            static const int qjstype = QVariant::fromValue(QJSValue()).userType();
+            if (qvar->userType() == qjstype) {
                 auto var = qvar->value<QJSValue>().toVariant();
                 packDataValue(&var, value);
             }

--- a/cpp/capi.cpp
+++ b/cpp/capi.cpp
@@ -743,6 +743,14 @@ void packDataValue(QVariant_ *var, DataValue *value)
             *(DataValue**)(value->data) = dvlist;
         }
         break;
+    case QMetaType::User:
+        {
+            if (qvar->userType() == 1034) {
+                auto var = qvar->value<QJSValue>().toVariant();
+                packDataValue(&var, value);
+            }
+        }
+        break;
     default:
         if (qvar->type() == (int)QMetaType::QObjectStar || qvar->canConvert<QObject *>()) {
             QObject *qobject = qvar->value<QObject *>();


### PR DESCRIPTION
Added proper casting from QMetaType::User (1024) with userType 1034 (i.e.,
QJSValue) to QVariant so it can be handled properly by the packDataValue
method.
