### PR TITLE
add AddImportPath

### DIFF
--- a/cpp/capi.cpp
+++ b/cpp/capi.cpp
@@ -163,6 +163,14 @@ void engineAddImageProvider(QQmlEngine_ *engine, QString_ *providerId, void *ima
     qengine->addImageProvider(*qproviderId, new GoImageProvider(imageFunc));
 }
 
+void engineAddImportPath(QQmlEngine_ *engine, QString_ *path)
+{
+    QQmlEngine *qengine = reinterpret_cast<QQmlEngine *>(engine);
+    QString *qpath = reinterpret_cast<QString *>(path);
+
+    qengine->addImportPath(*qpath);
+}
+
 void componentLoadURL(QQmlComponent_ *component, const char *url, int urlLen)
 {
     QByteArray qurl(url, urlLen);

--- a/cpp/capi.h
+++ b/cpp/capi.h
@@ -122,6 +122,7 @@ void engineSetOwnershipCPP(QQmlEngine_ *engine, QObject_ *object);
 void engineSetOwnershipJS(QQmlEngine_ *engine, QObject_ *object);
 void engineSetContextForObject(QQmlEngine_ *engine, QObject_ *object);
 void engineAddImageProvider(QQmlEngine_ *engine, QString_ *providerId, void *imageFunc);
+void engineAddImportPath(QQmlEngine_ *engine, QString_ *path);
 
 void contextGetProperty(QQmlContext_ *context, QString_ *name, DataValue *value);
 void contextSetProperty(QQmlContext_ *context, QString_ *name, DataValue *value);

--- a/qml.go
+++ b/qml.go
@@ -241,6 +241,22 @@ func (e *Engine) AddImageProvider(prvId string, f func(imgId string, width, heig
 	})
 }
 
+// AddImportPath adds path as a directory where the engine searches for installed modules in a
+// URL-based directory structure.
+//
+// The path may be a local filesystem directory, a Qt Resource path (:/imports),
+// a Qt Resource url (qrc:/imports) or a URL.
+//
+// The newly added path will be first in the importPathList().
+func (e *Engine) AddImportPath(path string) {
+	cpath, cpathLen := unsafeStringData(path)
+	RunMain(func() {
+		qpath := C.newString(cpath, cpathLen)
+		defer C.delString(qpath)
+		C.engineAddImportPath(e.addr, qpath)
+	})
+}
+
 //export hookRequestImage
 func hookRequestImage(imageFunc unsafe.Pointer, cid *C.char, cidLen, cwidth, cheight C.int) unsafe.Pointer {
 	f := *(*func(imgId string, width, height int) image.Image)(imageFunc)


### PR DESCRIPTION
AddImportPath adds path as a directory where the engine searches for installed modules.

If this is set to something like engine.AddImportPath("qrc:/assets") , one can copy whole Qt/QtQuick qml/ directory to assets/ and distribute everything in single binary.
