### PR TITLE
Task switcher fixes

### DIFF
--- a/cpp/capi.cpp
+++ b/cpp/capi.cpp
@@ -244,6 +244,13 @@ uintptr_t windowPlatformId(QQuickWindow_ *win)
     return reinterpret_cast<QQuickWindow *>(win)->winId();
 }
 
+void windowSetIcon(QQuickWindow_ *win, QString_ *iconPath)
+{
+  const QString *qiconPath = reinterpret_cast<QString *>(iconPath);
+  const QIcon *icon = new QIcon(*qiconPath);
+  reinterpret_cast<QQuickWindow *>(win)->setIcon(*icon);
+}
+
 void windowConnectHidden(QQuickWindow_ *win)
 {
     QQuickWindow *qwin = reinterpret_cast<QQuickWindow *>(win);

--- a/cpp/capi.cpp
+++ b/cpp/capi.cpp
@@ -45,8 +45,7 @@ void panicf(const char *format, ...)
 
 void newGuiApplication()
 {
-    static char empty[1] = {0};
-    static char *argv[] = {empty, 0};
+    static char *argv[] = {(char *)"go-qml", 0};
     static int argc = 1;
     new QApplication(argc, argv);
 

--- a/cpp/capi.h
+++ b/cpp/capi.h
@@ -153,6 +153,7 @@ QQuickWindow_ *componentCreateWindow(QQmlComponent_ *component, QQmlContext_ *co
 void windowShow(QQuickWindow_ *win);
 void windowHide(QQuickWindow_ *win);
 uintptr_t windowPlatformId(QQuickWindow_ *win);
+void windowSetIcon(QQuickWindow_ *win, QString_ *iconPath);
 void windowConnectHidden(QQuickWindow_ *win);
 QObject_ *windowRootObject(QQuickWindow_ *win);
 QImage_ *windowGrabWindow(QQuickWindow_ *win);

--- a/qml.go
+++ b/qml.go
@@ -885,6 +885,15 @@ func (win *Window) PlatformId() uintptr {
 	return id
 }
 
+func (win *Window) SetIcon(iconPath string) {
+	ciconPath, ciconPathLen := unsafeStringData(iconPath)
+	RunMain(func() {
+		qiconPath := C.newString(ciconPath, ciconPathLen)
+		defer C.delString(qiconPath)
+		C.windowSetIcon(win.addr, qiconPath)
+	})
+}
+
 // Root returns the root object being rendered.
 //
 // If the window was defined in QML code, the root object is the window itself.


### PR DESCRIPTION
This pull request does two things that makes my go-qml application appear correctly in the Gnome 3 task switcher.
- It adds window.SetIcon, which allows setting the application icon at runtime. I couldn't figure out any way to do this using qml, but please correct me if I'm wrong here
- It adds an actual name to QT:s argv when starting the application. This prevenst QT from reporting the application name as null to the windowing system, and in turn allows me to set the application name nicely with a .desktop file. Prior art for this is here:
  http://trac.gekkou.co.uk/hsqml/ticket/34
